### PR TITLE
Modularize scheduling logic with JSON import/export

### DIFF
--- a/Project_Planner_App.html
+++ b/Project_Planner_App.html
@@ -436,7 +436,11 @@
     async function ensureCHART(){ if(window.Chart) return true; for(const src of CHART_SOURCES){ try{ await loadScript(src); if(window.Chart) return true; }catch(e){} } return !!window.Chart; }
   </script>
 
-  <script>
+  <script type="module">
+    import { aggregate, computeSchedule } from './schedule.js';
+    import { exportPlanJSON, importPlanJSON, validateColumns } from './export.js';
+    import { state, load, save, getTeam, getPhase, getProject } from './data.js';
+    load();
     /* ===================== APP CODE (v20) ===================== */
     const STORAGE_KEY = "project_planner_v20";
     const dayMs = 86400000;
@@ -534,23 +538,15 @@ function seedEffortsFromBaselineGlobal(){
 
 
     /* ---------- State ---------- */
-    let state = load();
-    function load(){ try{ const raw=localStorage.getItem(STORAGE_KEY); if(raw) return JSON.parse(raw);}catch(e){} return structuredClone(DEFAULT_DATA); }
-    function save(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); toast("Saved"); }
     function toast(msg){ const el=document.getElementById('appToast'); document.getElementById('toastBody').textContent=msg; const t=new bootstrap.Toast(el,{delay:1400}); t.show(); }
     function byId(id){ return document.getElementById(id); }
-    function addDays(d, n){ const x=new Date(d.getTime()); x.setDate(x.getDate()+n); return x; }
     function daysBetween(a,b){ return Math.ceil((b-a)/dayMs); }
     function fmt(d){ return d.toLocaleDateString('en-GB',{day:'2-digit',month:'short'}); }
     function iso(d){ return d.toISOString().slice(0,10); }
     function escapeHtml(s){
       return (s||'').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;');
     }
-    function getTeam(teamId){ return state.teams.find(t=>t.id===teamId); }
-    function getPhase(phaseId){ return state.phases.find(p=>p.id===phaseId); }
-    
     function getProposal(id){ return (state.proposals||[]).find(p=> p.id===id); }
-function getProject(projectId){ return state.projects.find(p=>p.id===projectId); }
     function slug(s){ return (s||"").replace(/[^A-Za-z0-9]+/g,'_').slice(0,28) || 'Sheet'; }
 
     
@@ -584,87 +580,6 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
     }
 
     /* ---------- Aggregation & Schedule ---------- */
-    
-    function aggregate(plan){
-      const team = getTeam(plan.teamId)?.sizes || {BE:0,iOS:0,Android:0,Online:0,QA:0};
-      const buffer = (plan.bufferPct||0)/100;
-      const phaseTotals = {};
-      for(const pid of plan.phaseIds){ phaseTotals[pid] = {BE:0,iOS:0,Android:0,Online:0,QA:0, earliest:null}; }
-      state.tasks.forEach(t=>{
-        if(t.projectId !== plan.projectId) return;
-        const earliestTaskStart = (t.startDate && t.startDate.trim()) ? new Date(t.startDate) : null;
-        (t.assignments||[]).forEach(a=>{
-          if(a.proposalId!==plan.id) return;
-          const rec = phaseTotals[a.phaseId] || (phaseTotals[a.phaseId]={BE:0,iOS:0,Android:0,Online:0,QA:0,earliest:null});
-          (t.efforts||[]).forEach(eff=>{
-            const md = +eff.manDays || 0; const plat = eff.platform;
-            if(plat in rec){ rec[plat] = (rec[plat]||0) + md; }
-          });
-          if(earliestTaskStart){ rec.earliest = (!rec.earliest || earliestTaskStart < rec.earliest) ? earliestTaskStart : rec.earliest; }
-        });
-      });
-      for(const phId of Object.keys(phaseTotals)) ["BE","iOS","Android","Online","QA"].forEach(k=> phaseTotals[phId][k] = +(phaseTotals[phId][k] * (1+buffer)).toFixed(1));
-      return { team, buffer, phaseTotals };
-    }
-
-    function duration(md, eng, eff){ if(!eng||eng<=0) return 0; return Math.max(1, Math.ceil(md/(eng*eff))); }
-    function computeSchedule(plan, aggr, eff){
-      const planStart = new Date(state.meta.startDate);
-      const phases = plan.phaseIds.map(id=> getPhase(id)).filter(Boolean).sort((a,b)=>(a.order||0)-(b.order||0));
-      const lanes = [
-        {key:'BE', name:'Backend', cls:'be'},
-        {key:'iOS', name:'iOS', cls:'ios'},
-        {key:'Android', name:'Android', cls:'android'},
-        {key:'Online', name:'Online/Web', cls:'web'},
-        {key:'QA', name:'QA (Manual)', cls:'qa'}
-      ];
-      const phaseWindows = [];
-      let prevEnd = null;
-      for(const ph of phases){
-        const totals = aggr.phaseTotals[ph.id] || {BE:0,iOS:0,Android:0,Online:0,QA:0,earliest:null};
-        let phStart = prevEnd ? addDays(prevEnd, 1) : planStart;
-        if(totals.earliest && totals.earliest > phStart) phStart = totals.earliest;
-        const beDays = duration(totals.BE, aggr.team.BE, eff);
-        const iosDays = duration(totals.iOS, aggr.team.iOS, eff);
-        const andDays = duration(totals.Android, aggr.team.Android, eff);
-        const webDays = duration(totals.Online, aggr.team.Online, eff);
-        const feMax = Math.max(iosDays, andDays, webDays);
-        let beStart = phStart;
-        let iosStart = addDays(phStart, 5);
-        let andStart = addDays(phStart, 5);
-        let webStart = addDays(phStart, 5);
-        let qaStart = addDays(iosStart, Math.floor(feMax*0.5));
-        const o = plan.overrides?.[ph.id] || {};
-        if(o.BE) beStart = new Date(o.BE);
-        if(o.iOS) iosStart = new Date(o.iOS);
-        if(o.Android) andStart = new Date(o.Android);
-        if(o.Online) webStart = new Date(o.Online);
-        if(o.QA) qaStart = new Date(o.QA);
-        const beEnd = addDays(beStart, beDays);
-        const iosEnd = addDays(iosStart, iosDays);
-        const andEnd = addDays(andStart, andDays);
-        const webEnd = addDays(webStart, webDays);
-        const qaEnd = addDays(qaStart, duration(totals.QA, aggr.team.QA, eff));
-        const phEnd = new Date(Math.max(beEnd, iosEnd, andEnd, webEnd, qaEnd));
-        phaseWindows.push({
-          ph: ph.id,
-          start: phStart,
-          end: phEnd,
-          lanes: [
-            {key:'BE', start: beStart, days: beDays},
-            {key:'iOS', start: iosStart, days: iosDays},
-            {key:'Android', start: andStart, days: andDays},
-            {key:'Online', start: webStart, days: webDays},
-            {key:'QA', start: qaStart, days: duration(totals.QA, aggr.team.QA, eff)}
-          ]
-        });
-        prevEnd = phEnd;
-      }
-      const chartStart = phaseWindows.length ? phaseWindows[0].start : planStart;
-      const chartEnd = phaseWindows.length ? phaseWindows[phaseWindows.length-1].end : planStart;
-      return { chartStart, chartEnd, lanes, phaseWindows };
-    }
-
     
     // Populate per-assignment efforts from BASELINE so calculations come from tasks directly.
     
@@ -704,8 +619,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       if(byId('btn-open-efforts')){ byId('btn-open-efforts').onclick = ()=>{ const mm=new bootstrap.Modal(byId('manageModal')); mm.show(); byId('tab-efforts').click(); byId('eff-proj').value = projectId; byId('eff-proj').dispatchEvent(new Event('change')); }; }
     }
     function planCard(p){
-      const aggr = aggregate(p);
-      const sched = computeSchedule(p, aggr, state.meta.efficiency);
+      const aggr = aggregate(p, state.tasks, getTeam);
+      const sched = computeSchedule(p, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
       const totals = {BE:0,iOS:0,Android:0,Online:0,QA:0};
       Object.values(aggr.phaseTotals).forEach(pt=>{ for(const k in totals){ totals[k]+=(pt[k]||0);} });
       for(const k in totals) totals[k] = +totals[k].toFixed(1);
@@ -754,8 +669,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       currentPlanId = planId;
       byId('plansLayer').style.display='none';
       byId('detail').style.display='block';
-      const aggr = aggregate(p);
-      const sched = computeSchedule(p, aggr, state.meta.efficiency);
+      const aggr = aggregate(p, state.tasks, getTeam);
+      const sched = computeSchedule(p, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
       byId('detail-title').textContent = p.title;
       byId('detail-team').textContent = getTeam(p.teamId)?.name || '—';
       byId('detail-buffer').textContent = p.bufferPct||0;
@@ -775,7 +690,7 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       });
       drawGantt(p, sched);
       renderPhaseBreakdownTables(p);
-      document.querySelectorAll('.lane-filter').forEach(chk=> chk.onchange = ()=> drawGantt(p, computeSchedule(p, aggregate(p), state.meta.efficiency)));
+      document.querySelectorAll('.lane-filter').forEach(chk=> chk.onchange = ()=> drawGantt(p, computeSchedule(p, aggregate(p, state.tasks, getTeam), state.meta.efficiency, getPhase, state.meta.startDate)));
       byId('zoomRange').value = p.pxPerDay || state.meta.defaultPxPerDay || 18;
       byId('btn-back-plans').onclick = ()=> { openProject(p.projectId); };
       byId('btn-export-plan-pdf').onclick = ()=> exportPlanPDF(p.id);
@@ -902,8 +817,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       const acc = byId('phaseBreakdown'); acc.innerHTML='';
       plan.phaseIds.forEach((phId, idx)=>{
         const ph = getPhase(phId);
-        const aggr = aggregate(plan);
-        const sched = computeSchedule(plan, aggr, state.meta.efficiency);
+        const aggr = aggregate(plan, state.tasks, getTeam);
+        const sched = computeSchedule(plan, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
         const win = sched.phaseWindows.find(w=> w.ph===phId);
         const span = win ? `${fmt(win.start)} → ${fmt(win.end)} (${daysBetween(win.start, win.end)} days)` : '';
         const data = computeTaskEffortsForPhase(plan, phId);
@@ -962,8 +877,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
     /* ---------- PDF Export (unchanged) ---------- */
     
     function buildStaticTimelineNode(plan){
-      const aggr = aggregate(plan);
-      const sched = computeSchedule(plan, aggr, state.meta.efficiency);
+      const aggr = aggregate(plan, state.tasks, getTeam);
+      const sched = computeSchedule(plan, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
       // A4 landscape content width ~1100px; respect padding used in .pdf-sheet (24px)
       const pageWidth = 1100 - 2*24;
       const labelPad = 140;
@@ -1010,7 +925,7 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       const node = document.createElement('div');
       const title = document.createElement('div'); title.className='pdf-h2'; title.textContent = plan.title;
       const meta = document.createElement('div'); meta.className='pdf-meta';
-      const aggr = aggregate(plan); const sched = computeSchedule(plan, aggr, state.meta.efficiency);
+      const aggr = aggregate(plan, state.tasks, getTeam); const sched = computeSchedule(plan, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
       meta.textContent = `Team: ${getTeam(plan.teamId)?.name||'—'} • Buffer ${plan.bufferPct||0}% • ${fmt(sched.chartStart)} → ${fmt(sched.chartEnd)}`;
       node.appendChild(title); node.appendChild(meta);
       node.appendChild(buildStaticTimelineNode(plan));
@@ -1104,8 +1019,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       const pr = getProject(projectId);
       const sheet = [["Project", pr?.name||"—"], ["Generated", new Date().toLocaleString()], [""], ["Plan","Team","Phases","Buffer%","Start","End","BE","iOS","Android","Online","QA"]];
       state.proposals.filter(p=>p.projectId===projectId).forEach(p=>{
-        const aggr = aggregate(p);
-        const sched = computeSchedule(p, aggr, state.meta.efficiency);
+        const aggr = aggregate(p, state.tasks, getTeam);
+        const sched = computeSchedule(p, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
         const totals = {BE:0,iOS:0,Android:0,Online:0,QA:0};
         Object.values(aggr.phaseTotals).forEach(pt=>{ for(const k in totals){ totals[k]+=(pt[k]||0);} });
         sheet.push([p.title, getTeam(p.teamId)?.name||"—", p.phaseIds.map(id=>getPhase(id)?.name||id).join(" / "), p.bufferPct||0, sched.chartStart.toISOString().slice(0,10), sched.chartEnd.toISOString().slice(0,10), totals.BE, totals.iOS, totals.Android, totals.Online, totals.QA]);
@@ -1122,8 +1037,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       XLSX.writeFile(wb, (p?.title||"Plan")+"_Delivery.xlsx");
     }
     function buildPlanSheetsForExcelBasic(wb, plan){
-      const aggr = aggregate(plan);
-      const sched = computeSchedule(plan, aggr, state.meta.efficiency);
+      const aggr = aggregate(plan, state.tasks, getTeam);
+      const sched = computeSchedule(plan, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
       const overview = [
         ["Delivery Plan", plan.title],
         ["Project", getProject(plan.projectId)?.name||"—"],
@@ -1191,8 +1106,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       let r=5;
       const totalsAll = {BE:0,iOS:0,Android:0,Online:0,QA:0};
       for(const p of plans){
-        const aggr = aggregate(p);
-        const sched = computeSchedule(p, aggr, state.meta.efficiency);
+        const aggr = aggregate(p, state.tasks, getTeam);
+        const sched = computeSchedule(p, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
         const totals = {BE:0,iOS:0,Android:0,Online:0,QA:0};
         Object.values(aggr.phaseTotals).forEach(pt=>{ for(const k in totals){ totals[k]+=(pt[k]||0);} });
         for(const k in totals){ totalsAll[k]+=totals[k]; }
@@ -1230,8 +1145,8 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=(p?.title||"Plan")+"_Delivery_Styled.xlsx"; a.click(); URL.revokeObjectURL(a.href);
     }
     async function buildPlanSheetsStyled(wb, plan){
-      const aggr = aggregate(plan);
-      const sched = computeSchedule(plan, aggr, state.meta.efficiency);
+      const aggr = aggregate(plan, state.tasks, getTeam);
+      const sched = computeSchedule(plan, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
       // Overview
       const shO = wb.addSheet(sheetName(plan.title,"_Overview"));
       shO.cell("A1").value("Delivery Plan").style({bold:true, fill:"FFE699"});
@@ -1339,6 +1254,7 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
           out.push(cur); return out;
         });
         const headers = rows.shift().map(h=>h.trim().toLowerCase());
+        validateColumns(Object.fromEntries(headers.map(h=>[h,true])), ['id','title','assignments']);
         const idx = (k)=> headers.indexOf(k);
         rows.forEach(cols=>{
           if(!cols.length) return;
@@ -1410,7 +1326,7 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
       const filterPl = (byId('search-plans').value||'').toLowerCase();
       const tbPl = byId('tbl-plans').querySelector('tbody'); tbPl.innerHTML='';
       state.proposals.filter(p=> (p.title+' '+p.id).toLowerCase().includes(filterPl)).forEach(p=>{
-        const aggr = aggregate(p);
+        const aggr = aggregate(p, state.tasks, getTeam);
         const totals = {BE:0,iOS:0,Android:0,Online:0,QA:0};
         Object.values(aggr.phaseTotals).forEach(pt=>{ for(const k in totals){ totals[k]+=(pt[k]||0);} });
         const sumEff = totals.BE+totals.iOS+totals.Android+totals.Online+totals.QA || 1;
@@ -1699,10 +1615,17 @@ function getProject(projectId){ return state.projects.find(p=>p.id===projectId);
 
     /* ---------- Export/Import/Reset ---------- */
     byId('btn-export').onclick = ()=>{
-      const blob = new Blob([JSON.stringify(state,null,2)], {type:'application/json'});
+      let data;
+      if(currentPlanId){
+        const plan = state.proposals.find(p=>p.id===currentPlanId);
+        data = exportPlanJSON(plan);
+      }else{
+        data = JSON.stringify(state,null,2);
+      }
+      const blob = new Blob([data], {type:'application/json'});
       const url = URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='project_planner_v20.json'; a.click(); URL.revokeObjectURL(url);
     };
-    byId('file-import').onchange = (e)=>{ const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ try{ state=JSON.parse(r.result); save(); applyTheme(state.meta.theme||"Dark"); document.documentElement.setAttribute('dir', state.meta.rtl ? 'rtl' : 'ltr'); try{ let need=false; (state.tasks||[]).forEach(t=>{ if(!t.efforts || !t.efforts.length) need=true; }); if(need){ seedEffortsFromBaselineGlobal(); save(); } }catch(e){}
+    byId('file-import').onchange = (e)=>{ const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ try{ const obj=JSON.parse(r.result); if(obj.phaseIds){ state.proposals.push(importPlanJSON(r.result)); } else { state=obj; } save(); applyTheme(state.meta.theme||"Dark"); document.documentElement.setAttribute('dir', state.meta.rtl ? 'rtl' : 'ltr'); try{ let need=false; (state.tasks||[]).forEach(t=>{ if(!t.efforts || !t.efforts.length) need=true; }); if(need){ seedEffortsFromBaselineGlobal(); save(); } }catch(e){}
       buildProjects(); }catch(err){ alert('Invalid JSON: '+err); } }; r.readAsText(f); };
     byId('btn-reset').onclick = ()=>{ if(confirm('Reset to defaults?')){ state = structuredClone(DEFAULT_DATA); save(); applyTheme(state.meta.theme||"Dark"); document.documentElement.setAttribute('dir', state.meta.rtl ? 'rtl' : 'ltr'); try{ let need=false; (state.tasks||[]).forEach(t=>{ if(!t.efforts || !t.efforts.length) need=true; }); if(need){ seedEffortsFromBaselineGlobal(); save(); } }catch(e){}
       buildProjects(); } };

--- a/data.js
+++ b/data.js
@@ -1,0 +1,25 @@
+export const STORAGE_KEY = 'project_planner_state';
+export const state = {
+  projects: [],
+  proposals: [],
+  tasks: [],
+  teams: [],
+  phases: [],
+  meta: { startDate: new Date().toISOString().slice(0,10), efficiency: 1 }
+};
+
+export function load(){
+  try{
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if(raw) Object.assign(state, JSON.parse(raw));
+  }catch(e){}
+  return state;
+}
+
+export function save(){
+  try{ localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }catch(e){}
+}
+
+export function getTeam(teamId){ return state.teams.find(t => t.id === teamId); }
+export function getPhase(phaseId){ return state.phases.find(p => p.id === phaseId); }
+export function getProject(projectId){ return state.projects.find(p => p.id === projectId); }

--- a/export.js
+++ b/export.js
@@ -1,0 +1,16 @@
+export function exportPlanJSON(plan){
+  return JSON.stringify(plan, null, 2);
+}
+
+export function importPlanJSON(json){
+  const obj = JSON.parse(json);
+  if(!obj || typeof obj !== 'object') throw new Error('Invalid JSON');
+  if(!obj.id || !obj.name) throw new Error('Missing required fields');
+  return obj;
+}
+
+export function validateColumns(row, required){
+  const missing = required.filter(col => !(col in row));
+  if(missing.length) console.warn(`Missing columns: ${missing.join(', ')}`);
+  return missing;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "project-planner",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/schedule.js
+++ b/schedule.js
@@ -1,0 +1,83 @@
+export function aggregate(plan, tasks, getTeam){
+  const team = getTeam(plan.teamId)?.sizes || {BE:0,iOS:0,Android:0,Online:0,QA:0};
+  const buffer = (plan.bufferPct||0)/100;
+  const phaseTotals = {};
+  for(const pid of plan.phaseIds){ phaseTotals[pid] = {BE:0,iOS:0,Android:0,Online:0,QA:0,earliest:null}; }
+  tasks.forEach(t=>{
+    if(t.projectId !== plan.projectId) return;
+    const earliestTaskStart = (t.startDate && t.startDate.trim()) ? new Date(t.startDate) : null;
+    (t.assignments||[]).forEach(a=>{
+      if(a.proposalId!==plan.id) return;
+      const rec = phaseTotals[a.phaseId] || (phaseTotals[a.phaseId]={BE:0,iOS:0,Android:0,Online:0,QA:0,earliest:null});
+      (t.efforts||[]).forEach(eff=>{
+        const md = +eff.manDays || 0; const plat = eff.platform;
+        if(plat in rec){ rec[plat] = (rec[plat]||0) + md; }
+      });
+      if(earliestTaskStart){ rec.earliest = (!rec.earliest || earliestTaskStart < rec.earliest) ? earliestTaskStart : rec.earliest; }
+    });
+  });
+  for(const phId of Object.keys(phaseTotals)) ["BE","iOS","Android","Online","QA"].forEach(k=> phaseTotals[phId][k] = +(phaseTotals[phId][k] * (1+buffer)).toFixed(1));
+  return { team, buffer, phaseTotals };
+}
+
+function duration(md, eng, eff){ if(!eng||eng<=0) return 0; return Math.max(1, Math.ceil(md/(eng*eff))); }
+function addDays(d, n){ const x=new Date(d.getTime()); x.setDate(x.getDate()+n); return x; }
+
+export function computeSchedule(plan, aggr, eff, getPhase, startDate, options={}){
+  const planStart = new Date(startDate);
+  const phases = plan.phaseIds.map(id=> getPhase(id)).filter(Boolean).sort((a,b)=>(a.order||0)-(b.order||0));
+  const defaultLanes = [
+    {key:'BE', name:'Backend', cls:'be'},
+    {key:'iOS', name:'iOS', cls:'ios'},
+    {key:'Android', name:'Android', cls:'android'},
+    {key:'Online', name:'Online/Web', cls:'web'},
+    {key:'QA', name:'QA (Manual)', cls:'qa'}
+  ];
+  const lanes = options.lanes || defaultLanes;
+  const qaRule = options.qaStart || 'half'; // 'half' or 'afterFE'
+  const phaseWindows = [];
+  let prevEnd = null;
+  for(const ph of phases){
+    const totals = aggr.phaseTotals[ph.id] || {BE:0,iOS:0,Android:0,Online:0,QA:0,earliest:null};
+    let phStart = prevEnd ? addDays(prevEnd, 1) : planStart;
+    if(totals.earliest && totals.earliest > phStart) phStart = totals.earliest;
+    const beDays = duration(totals.BE, aggr.team.BE, eff);
+    const iosDays = duration(totals.iOS, aggr.team.iOS, eff);
+    const andDays = duration(totals.Android, aggr.team.Android, eff);
+    const webDays = duration(totals.Online, aggr.team.Online, eff);
+    const feMax = Math.max(iosDays, andDays, webDays);
+    let beStart = phStart;
+    let iosStart = addDays(phStart, 5);
+    let andStart = addDays(phStart, 5);
+    let webStart = addDays(phStart, 5);
+    let qaStart = qaRule==='afterFE' ? addDays(iosStart, feMax) : addDays(iosStart, Math.floor(feMax*0.5));
+    const o = plan.overrides?.[ph.id] || {};
+    if(o.BE) beStart = new Date(o.BE);
+    if(o.iOS) iosStart = new Date(o.iOS);
+    if(o.Android) andStart = new Date(o.Android);
+    if(o.Online) webStart = new Date(o.Online);
+    if(o.QA) qaStart = new Date(o.QA);
+    const beEnd = addDays(beStart, beDays);
+    const iosEnd = addDays(iosStart, iosDays);
+    const andEnd = addDays(andStart, andDays);
+    const webEnd = addDays(webStart, webDays);
+    const qaEnd = addDays(qaStart, duration(totals.QA, aggr.team.QA, eff));
+    const phEnd = new Date(Math.max(beEnd, iosEnd, andEnd, webEnd, qaEnd));
+    phaseWindows.push({
+      ph: ph.id,
+      start: phStart,
+      end: phEnd,
+      lanes: [
+        {key:'BE', start: beStart, days: beDays},
+        {key:'iOS', start: iosStart, days: iosDays},
+        {key:'Android', start: andStart, days: andDays},
+        {key:'Online', start: webStart, days: webDays},
+        {key:'QA', start: qaStart, days: duration(totals.QA, aggr.team.QA, eff)}
+      ]
+    });
+    prevEnd = phEnd;
+  }
+  const chartStart = phaseWindows.length ? phaseWindows[0].start : planStart;
+  const chartEnd = phaseWindows.length ? phaseWindows[phaseWindows.length-1].end : planStart;
+  return { chartStart, chartEnd, lanes, phaseWindows };
+}

--- a/tests/schedule.test.js
+++ b/tests/schedule.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { aggregate, computeSchedule } from '../schedule.js';
+
+const dayMs = 86400000;
+function dummyPhase(id){ return {id, order:1}; }
+function getTeam(){ return {sizes:{BE:1,iOS:1,Android:1,Online:1,QA:1}}; }
+function sampleTasks(){
+  return [{
+    projectId:1,
+    startDate:'2024-01-01',
+    assignments:[{proposalId:1, phaseId:'p1'}],
+    efforts:[{platform:'BE', manDays:10},{platform:'QA', manDays:2},{platform:'iOS', manDays:4}]
+  }];
+}
+
+test('aggregate applies buffer and handles zero team members', () => {
+  const plan = {id:1, projectId:1, teamId:1, phaseIds:['p1'], bufferPct:10};
+  const tasks = sampleTasks();
+  const getZeroTeam = () => ({sizes:{BE:0,iOS:1,Android:1,Online:1,QA:1}});
+  const aggr = aggregate(plan, tasks, getZeroTeam);
+  assert.strictEqual(aggr.phaseTotals['p1'].BE, 11);
+  assert.strictEqual(aggr.team.BE, 0);
+});
+
+test('computeSchedule supports QA after FE rule', () => {
+  const plan = {id:1, projectId:1, teamId:1, phaseIds:['p1']};
+  const tasks = sampleTasks();
+  const aggr = aggregate({...plan, bufferPct:0}, tasks, getTeam);
+  const sched = computeSchedule(plan, aggr, 1, dummyPhase, '2024-01-01', {qaStart:'afterFE'});
+  const lanes = sched.phaseWindows[0].lanes;
+  const ios = lanes.find(l=>l.key==='iOS');
+  const qa = lanes.find(l=>l.key==='QA');
+  const diffDays = Math.round((qa.start - ios.start)/dayMs);
+  assert.strictEqual(diffDays, ios.days);
+});
+
+test('computeSchedule respects overrides', () => {
+  const plan = {id:1, projectId:1, teamId:1, phaseIds:['p1'], overrides:{'p1':{QA:'2024-01-10'}}};
+  const tasks = sampleTasks();
+  const aggr = aggregate(plan, tasks, getTeam);
+  const sched = computeSchedule(plan, aggr, 1, dummyPhase, '2024-01-01');
+  const qa = sched.phaseWindows[0].lanes.find(l=>l.key==='QA');
+  assert.strictEqual(qa.start.toISOString().slice(0,10), '2024-01-10');
+});

--- a/ui/gantt.js
+++ b/ui/gantt.js
@@ -1,0 +1,6 @@
+import { computeSchedule } from '../schedule.js';
+
+export function renderGantt(plan, aggr, eff, getPhase, startDate, options){
+  const sched = computeSchedule(plan, aggr, eff, getPhase, startDate, options);
+  return sched; // placeholder for real rendering logic
+}


### PR DESCRIPTION
## Summary
- Refactor planner into ES modules: add schedule.js for aggregation/scheduling, export.js for JSON & CSV helpers, and data/ui scaffolding
- Support configurable scheduling rules like QA after FE via computeSchedule options
- Add JSON plan export/import and basic CSV column validation
- Introduce unit tests for aggregate and computeSchedule edge cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a219c96c18832e8c14141f0ccbbd82