### PR TITLE
Refactor Core Data models for Swift concurrency

### DIFF
--- a/ProjectPlannerApp/Sources/Phase.swift
+++ b/ProjectPlannerApp/Sources/Phase.swift
@@ -2,15 +2,19 @@ import CoreData
 
 @objc(Phase)
 @MainActor
-public class Phase: NSManagedObject, Identifiable {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Phase> {
+public class Phase: NSManagedObject {
+}
+
+@MainActor
+public extension Phase: Identifiable {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<Phase> {
         NSFetchRequest<Phase>(entityName: "Phase")
     }
 
-    @NSManaged public var id: UUID
-    @NSManaged public var name: String
-    @NSManaged public var order: Int16
-    @NSManaged public var project: Project?
-    @NSManaged public var tasks: Set<Task>?
-    @NSManaged public var plans: Set<Plan>?
+    @NSManaged var id: UUID
+    @NSManaged var name: String
+    @NSManaged var order: Int16
+    @NSManaged var project: Project?
+    @NSManaged var tasks: Set<Task>?
+    @NSManaged var plans: Set<Plan>?
 }

--- a/ProjectPlannerApp/Sources/Plan.swift
+++ b/ProjectPlannerApp/Sources/Plan.swift
@@ -2,15 +2,19 @@ import CoreData
 
 @objc(Plan)
 @MainActor
-public class Plan: NSManagedObject, Identifiable {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Plan> {
+public class Plan: NSManagedObject {
+}
+
+@MainActor
+public extension Plan: Identifiable {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<Plan> {
         NSFetchRequest<Plan>(entityName: "Plan")
     }
 
-    @NSManaged public var id: UUID
-    @NSManaged public var name: String
-    @NSManaged public var bufferPct: Double
-    @NSManaged public var project: Project?
-    @NSManaged public var team: Team?
-    @NSManaged public var phases: Set<Phase>?
+    @NSManaged var id: UUID
+    @NSManaged var name: String
+    @NSManaged var bufferPct: Double
+    @NSManaged var project: Project?
+    @NSManaged var team: Team?
+    @NSManaged var phases: Set<Phase>?
 }

--- a/ProjectPlannerApp/Sources/Project.swift
+++ b/ProjectPlannerApp/Sources/Project.swift
@@ -2,14 +2,18 @@ import CoreData
 
 @objc(Project)
 @MainActor
-public class Project: NSManagedObject, Identifiable {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Project> {
+public class Project: NSManagedObject {
+}
+
+@MainActor
+public extension Project: Identifiable {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<Project> {
         NSFetchRequest<Project>(entityName: "Project")
     }
 
-    @NSManaged public var id: UUID
-    @NSManaged public var name: String
-    @NSManaged public var tasks: Set<Task>?
-    @NSManaged public var phases: Set<Phase>?
-    @NSManaged public var plans: Set<Plan>?
+    @NSManaged var id: UUID
+    @NSManaged var name: String
+    @NSManaged var tasks: Set<Task>?
+    @NSManaged var phases: Set<Phase>?
+    @NSManaged var plans: Set<Plan>?
 }

--- a/ProjectPlannerApp/Sources/Task.swift
+++ b/ProjectPlannerApp/Sources/Task.swift
@@ -2,15 +2,19 @@ import CoreData
 
 @objc(Task)
 @MainActor
-public class Task: NSManagedObject, Identifiable {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Task> {
+public class Task: NSManagedObject {
+}
+
+@MainActor
+public extension Task: Identifiable {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<Task> {
         NSFetchRequest<Task>(entityName: "Task")
     }
 
-    @NSManaged public var id: UUID
-    @NSManaged public var name: String
-    @NSManaged public var startDate: Date?
-    @NSManaged public var project: Project?
-    @NSManaged public var phases: Set<Phase>?
-    @NSManaged public var efforts: Set<TaskEffort>?
+    @NSManaged var id: UUID
+    @NSManaged var name: String
+    @NSManaged var startDate: Date?
+    @NSManaged var project: Project?
+    @NSManaged var phases: Set<Phase>?
+    @NSManaged var efforts: Set<TaskEffort>?
 }

--- a/ProjectPlannerApp/Sources/Team.swift
+++ b/ProjectPlannerApp/Sources/Team.swift
@@ -2,17 +2,21 @@ import CoreData
 
 @objc(Team)
 @MainActor
-public class Team: NSManagedObject, Identifiable {
-    @nonobjc public class func fetchRequest() -> NSFetchRequest<Team> {
+public class Team: NSManagedObject {
+}
+
+@MainActor
+public extension Team: Identifiable {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<Team> {
         NSFetchRequest<Team>(entityName: "Team")
     }
 
-    @NSManaged public var id: UUID
-    @NSManaged public var name: String
-    @NSManaged public var be: Double
-    @NSManaged public var ios: Double
-    @NSManaged public var android: Double
-    @NSManaged public var online: Double
-    @NSManaged public var qa: Double
-    @NSManaged public var plans: Set<Plan>?
+    @NSManaged var id: UUID
+    @NSManaged var name: String
+    @NSManaged var be: Double
+    @NSManaged var ios: Double
+    @NSManaged var android: Double
+    @NSManaged var online: Double
+    @NSManaged var qa: Double
+    @NSManaged var plans: Set<Plan>?
 }


### PR DESCRIPTION
## Summary
- Isolate Core Data NSManagedObject subclasses on the main actor
- Move `Identifiable` conformance into `@MainActor` extensions for safe access

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a4b66fcefc832eb81fbf6e9d49e8f9