### PR TITLE
Add debounced task search in phase assignments

### DIFF
--- a/Project_Planner_App.html
+++ b/Project_Planner_App.html
@@ -352,6 +352,7 @@
               <div class="d-flex align-items-center gap-2 mb-2">
                 <label class="form-label mb-0">Project</label>
                 <select id="pt-proj" class="form-select" style="max-width:240px"></select>
+                <input id="pt-search" type="search" class="form-control" placeholder="Search tasks" style="max-width:260px">
                 <div class="btn-group" role="group">
                   <button id="pt-view-board" class="btn btn-outline-secondary btn-sm active"><i class="bi bi-kanban"></i></button>
                   <button id="pt-view-matrix" class="btn btn-outline-secondary btn-sm"><i class="bi bi-table"></i></button>
@@ -1570,9 +1571,13 @@
       const ptBoard = byId('phaseTaskContainers');
       const ptBoardBtn = byId('pt-view-board');
       const ptMatrixBtn = byId('pt-view-matrix');
+      const ptSearch = byId('pt-search');
       let ptView = 'board';
       let dragEl = null; let dragSet = [];
       if(ptBoard){
+        function debounce(fn, delay=200){
+          let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), delay); };
+        }
         ptProjSel.innerHTML = (state.projects||[]).map(p=>`<option value="${p.id}">${p.name}</option>`).join('');
         if(!ptProjSel.value && state.projects[0]) ptProjSel.value = state.projects[0].id;
         function createTaskElem(id, title, isPool){
@@ -1652,6 +1657,8 @@
         }
         function renderPhaseTasks(){
           const pid = ptProjSel.value;
+          const q = (ptSearch?.value || '').toLowerCase();
+          const tasks = getTasksByProject(pid).filter(t => (t.title + ' ' + t.id).toLowerCase().includes(q));
           ptBoard.className='d-flex flex-wrap gap-3 align-items-stretch';
           ptBoard.innerHTML = '';
           const poolBox=document.createElement('div');
@@ -1659,7 +1666,7 @@
           poolBox.innerHTML='<div class="card-header d-flex align-items-center justify-content-between"><span>Tasks</span><button class="btn btn-sm btn-outline-secondary" id="pt-select-all">Select All</button></div><div class="card-body pt-drop vstack gap-1" id="pt-pool"></div>';
           ptBoard.appendChild(poolBox);
           const pool=byId('pt-pool');
-          getTasksByProject(pid).forEach(t=>{ pool.appendChild(createTaskElem(t.id, t.title, true)); });
+          tasks.forEach(t=>{ pool.appendChild(createTaskElem(t.id, t.title, true)); });
           poolBox.querySelector('#pt-select-all').onclick=()=>{
             const tasks=Array.from(pool.querySelectorAll('.pt-task'));
             const allSel=tasks.every(el=> el.classList.contains('selected'));
@@ -1672,7 +1679,7 @@
             box.innerHTML=`<div class="card-header">${ph.name}</div><div class="card-body pt-drop vstack gap-1" data-ph="${ph.id}"></div>`;
             ptBoard.appendChild(box);
           });
-          getTasksByProject(pid).forEach(t=>{
+          tasks.forEach(t=>{
             getTaskPhaseIds(t).forEach(phId=>{
               const dest=ptBoard.querySelector(`[data-ph="${phId}"]`);
               if(dest) dest.appendChild(createTaskElem(t.id, t.title, false));
@@ -1683,6 +1690,7 @@
         }
         function renderPhaseTaskMatrix(){
           const pid = ptProjSel.value;
+          const q = (ptSearch?.value || '').toLowerCase();
           ptBoard.className='table-responsive pt-matrix-wrapper';
           ptBoard.innerHTML='';
           const tbl=document.createElement('table');
@@ -1695,7 +1703,7 @@
           thead.appendChild(headRow);
           tbl.appendChild(thead);
           const tbody=document.createElement('tbody');
-          const tasks=getTasksByProject(pid);
+          const tasks=getTasksByProject(pid).filter(t => (t.title + ' ' + t.id).toLowerCase().includes(q));
           tasks.forEach(t=>{
             const tr=document.createElement('tr');
             const tdTitle=document.createElement('td');
@@ -1721,6 +1729,9 @@
         ptProjSel.onchange = ()=>{ ptView==='board'? renderPhaseTasks() : renderPhaseTaskMatrix(); };
         ptBoardBtn.onclick = ()=>{ ptView='board'; ptBoardBtn.classList.add('active'); ptMatrixBtn.classList.remove('active'); renderPhaseTasks(); };
         ptMatrixBtn.onclick = ()=>{ ptView='matrix'; ptMatrixBtn.classList.add('active'); ptBoardBtn.classList.remove('active'); renderPhaseTaskMatrix(); };
+        if(ptSearch){
+          ptSearch.addEventListener('input', debounce(()=>{ ptView==='board'? renderPhaseTasks() : renderPhaseTaskMatrix(); }, 200));
+        }
         renderPhaseTasks();
         const saveBtn = byId('pt-save');
         if(saveBtn) saveBtn.onclick = ()=>{


### PR DESCRIPTION
## Summary
- Add search input in Phase Tasks pane
- Filter phase tasks by search query with debounced input
- Keep tag badges accurate after filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4bb8f84e4832eb2270b0f75291a00