### PR TITLE
Enhance project dashboard and import

### DIFF
--- a/Project_Planner_App.html
+++ b/Project_Planner_App.html
@@ -519,7 +519,7 @@
   <script type="module">
       import { aggregate, computeSchedule } from './schedule.js';
       import { exportPlanJSON, importPlanJSON, validateColumns } from './export.js';
-      import { state, load, save, getTeam, getPhase, getProject, replaceState, assignTaskToPhase, getTaskPhaseIds, getTasksByProject, getTasksByPhase, removeEffortType, DEFAULT_EFFORT_TYPES, ensureSprints, resetSprints } from './data.js';
+      import { state, load, save, getTeam, getPhase, getProject, replaceState, mergeState, assignTaskToPhase, getTaskPhaseIds, getTasksByProject, getTasksByPhase, removeEffortType, DEFAULT_EFFORT_TYPES, ensureSprints, resetSprints } from './data.js';
       load();
       ensureSprints();
     /* ===================== APP CODE (v20) ===================== */
@@ -682,12 +682,19 @@
       byId('plansLayer').style.display='none';
       byId('detail').style.display='none';
       state.projects.forEach(pr=>{
+        const plans = state.proposals.filter(p=>p.projectId===pr.id);
+        const details = plans.map(pl=>{
+          const aggr = aggregate(pl, state.tasks, getTeam);
+          const sched = computeSchedule(pl, aggr, state.meta.efficiency, getPhase, state.meta.startDate);
+          return `<li>${pl.title}: ${fmt(sched.chartStart)} → ${fmt(sched.chartEnd)}</li>`;
+        }).join('');
         const col = document.createElement('div'); col.className='col-12 col-md-6 col-xl-4';
         col.innerHTML = `<div class="card card-hover h-100"><div class="card-body d-flex flex-column gap-2">
           <h5 class="card-title mb-0">${pr.name}</h5>
           <div class="text-secondary small">${pr.description||''}</div>
+          ${details ? `<ul class="small mb-0 ps-3">${details}</ul>` : ''}
           <div class="d-flex justify-content-between align-items-center mt-2">
-            <div class="small text-secondary">Plans: <b>${state.proposals.filter(p=>p.projectId===pr.id).length}</b></div>
+            <div class="small text-secondary">Plans: <b>${plans.length}</b></div>
             <button class="btn btn-outline-primary btn-sm">Open</button>
           </div>
         </div></div>`;
@@ -722,7 +729,7 @@
       const seg = Object.fromEntries(keys.map(k=>[k, Math.max(2, Math.round(260*(totals[k]/sumEff)))]));
       const startStr = fmt(sched.chartStart), endStr = fmt(sched.chartEnd);
       const phases = p.phaseIds.map(id=> getPhase(id)?.name||id).join(' · ');
-      const col = document.createElement('div'); col.className='col-12 col-md-6 col-xl-4';
+      const col = document.createElement('div'); col.className='col-12 col-md-6';
       col.innerHTML = `<div class="card card-hover h-100" data-plan="${p.id}"><div class="card-body d-flex flex-column gap-2">
         <div class="d-flex justify-content-between align-items-start gap-2">
           <div><h5 class="card-title mb-0">${p.title}</h5><div class="text-secondary small">${p.description||''}</div></div>
@@ -2007,8 +2014,30 @@
       const blob = new Blob([data], {type:'application/json'});
       const url = URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='project_planner_v20.json'; a.click(); URL.revokeObjectURL(url);
     };
-      byId('file-import').onchange = (e)=>{ const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ try{ const obj=JSON.parse(r.result); if(obj.phaseIds){ state.proposals.push(importPlanJSON(r.result)); } else { replaceState(obj); } save(); applyTheme(state.meta.theme||"Dark"); document.documentElement.setAttribute('dir', state.meta.rtl ? 'rtl' : 'ltr'); try{ let need=false; (state.tasks||[]).forEach(t=>{ if(!t.efforts || !t.efforts.length) need=true; }); if(need){ seedEffortsFromBaselineGlobal(); save(); } }catch(e){}
-        buildProjects(); }catch(err){ alert('Invalid JSON: '+err); } }; r.readAsText(f); };
+      byId('file-import').onchange = (e)=>{
+        const f = e.target.files[0]; if(!f) return;
+        const r = new FileReader();
+        r.onload = ()=>{
+          try{
+            const obj = JSON.parse(r.result);
+            if(obj.phaseIds){
+              state.proposals.push(importPlanJSON(r.result));
+            }else if(obj.projects){
+              mergeState(obj);
+            }else{
+              replaceState(obj);
+            }
+            save();
+            applyTheme(state.meta.theme||"Dark");
+            document.documentElement.setAttribute('dir', state.meta.rtl ? 'rtl' : 'ltr');
+            try{ let need=false; (state.tasks||[]).forEach(t=>{ if(!t.efforts || !t.efforts.length) need=true; }); if(need){ seedEffortsFromBaselineGlobal(); save(); } }catch(e){}
+            buildProjects();
+          }catch(err){
+            alert('Invalid JSON: '+err);
+          }
+        };
+        r.readAsText(f);
+      };
       byId('btn-reset').onclick = ()=>{ if(confirm('Reset to defaults?')){ replaceState(structuredClone(DEFAULT_DATA)); save(); applyTheme(state.meta.theme||"Dark"); document.documentElement.setAttribute('dir', state.meta.rtl ? 'rtl' : 'ltr'); try{ let need=false; (state.tasks||[]).forEach(t=>{ if(!t.efforts || !t.efforts.length) need=true; }); if(need){ seedEffortsFromBaselineGlobal(); save(); } }catch(e){}
         buildProjects(); } };
     byId('themeSelect').onchange = (e)=>{ state.meta.theme = e.target.value; applyTheme(state.meta.theme); save(); };

--- a/data.js
+++ b/data.js
@@ -59,6 +59,16 @@ export function replaceState(newState){
   if(!Array.isArray(state.sprints)) state.sprints = [];
 }
 
+export function mergeState(newData){
+  if(Array.isArray(newData.projects)) newData.projects.forEach(p=> state.projects.push(p));
+  if(Array.isArray(newData.proposals)) newData.proposals.forEach(p=> state.proposals.push(p));
+  if(Array.isArray(newData.tasks)) newData.tasks.forEach(t=> state.tasks.push(t));
+  if(Array.isArray(newData.teams)) newData.teams.forEach(t=> state.teams.push(t));
+  if(Array.isArray(newData.phases)) newData.phases.forEach(ph=> state.phases.push(ph));
+  if(Array.isArray(newData.sprints)) newData.sprints.forEach(s=> state.sprints.push(s));
+  if(newData.meta) Object.assign(state.meta, newData.meta);
+}
+
 export function getEffortTypes(){
   return state.meta.effortTypes || [];
 }

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { state, replaceState, assignTaskToPhase, removeTaskFromPhase, getTasksByPhase, getTasksByProject } from '../data.js';
+import { state, replaceState, assignTaskToPhase, removeTaskFromPhase, getTasksByPhase, getTasksByProject, mergeState } from '../data.js';
 
 test('replaceState swaps state object contents', () => {
   const initial = {
@@ -121,4 +121,12 @@ test('getTasksByPhase uses assignments when phaseIds missing', () => {
   const res = getTasksByPhase('p','ph');
   assert.equal(res.length,1);
   assert.equal(res[0].id,'t');
+});
+
+test('mergeState appends projects without removing existing', () => {
+  replaceState({ projects:[{id:'a'}], proposals:[], tasks:[], teams:[], phases:[], sprints:[], meta:{} });
+  mergeState({ projects:[{id:'b'}], proposals:[], tasks:[], teams:[], phases:[], sprints:[], meta:{} });
+  assert.equal(state.projects.length,2);
+  assert.ok(state.projects.find(p=>p.id==='a'));
+  assert.ok(state.projects.find(p=>p.id==='b'));
 });


### PR DESCRIPTION
## Summary
- Show plan titles and date ranges in project cards for more context
- Switch plan cards to a two-column layout for clearer browsing
- Allow importing project JSON to merge with existing data and add new projects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4bc35c6f0832eb853e7f96e530295