### PR TITLE
Add Info.plist for ProjectPlannerApp and update package

### DIFF
--- a/ProjectPlannerApp/Info.plist
+++ b/ProjectPlannerApp/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>ProjectPlannerApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.ProjectPlannerApp</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/ProjectPlannerApp/Package.swift
+++ b/ProjectPlannerApp/Package.swift
@@ -14,7 +14,8 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "ProjectPlannerApp",
-            path: "Sources"
+            path: "Sources",
+            resources: [.process("Info.plist")]
         )
     ]
 )

--- a/ProjectPlannerApp/Sources/Info.plist
+++ b/ProjectPlannerApp/Sources/Info.plist
@@ -1,0 +1,1 @@
+../Info.plist


### PR DESCRIPTION
## Summary
- Add Info.plist defining bundle metadata for ProjectPlannerApp
- Configure Package.swift to process the Info.plist for the executable target

## Testing
- `swift build` *(fails: 'resource Info.plist in target ProjectPlannerApp is forbidden; Info.plist is not supported as a top-level resource file in the resources bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9f49450832eb82cf1876da9768c