### PR TITLE
Set bundle identifier for macOS builds

### DIFF
--- a/ProjectPlannerApp/Package.swift
+++ b/ProjectPlannerApp/Package.swift
@@ -14,8 +14,7 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "ProjectPlannerApp",
-            path: "Sources",
-            resources: [.process("Info.plist")]
+            path: "Sources"
         )
     ]
 )

--- a/ProjectPlannerApp/Sources/Info.plist
+++ b/ProjectPlannerApp/Sources/Info.plist
@@ -1,1 +1,0 @@
-../Info.plist

--- a/ProjectPlannerApp/Sources/ProjectPlannerApp.swift
+++ b/ProjectPlannerApp/Sources/ProjectPlannerApp.swift
@@ -1,9 +1,19 @@
 import SwiftUI
 import CoreData
+#if os(macOS)
+import Foundation
+#endif
 
 @main
 @MainActor
 struct ProjectPlannerApp: App {
+    init() {
+        #if os(macOS)
+        // Assign a bundle identifier when running outside of an app bundle
+        Bundle.main.setValue("com.example.ProjectPlannerApp", forKey: "bundleIdentifier")
+        #endif
+    }
+
     let persistenceController = PersistenceController.shared
 
     var body: some Scene {


### PR DESCRIPTION
## Summary
- remove Info.plist resource to simplify SPM target
- assign bundle identifier at runtime when launching the SwiftUI app

## Testing
- `swift build` *(fails: no such module 'SwiftUI'—SwiftUI isn't available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e92dfca0832e8c429a4ceecbccd2