### PR TITLE
Use floor for hover day calculation

### DIFF
--- a/Project_Planner_App.html
+++ b/Project_Planner_App.html
@@ -922,7 +922,7 @@
         if(x < labelPad || x > labelPad + totalDays*pxPerDay){ hoverLine.style.display='none'; hoverLabel.style.display='none'; return; }
         hoverLine.style.display='block'; hoverLabel.style.display='block';
         hoverLine.style.left = x+'px'; hoverLabel.style.left = x+'px';
-        const d = Math.round((x - labelPad)/pxPerDay);
+        const d = Math.floor((x - labelPad)/pxPerDay);
         const dt = new Date(chartStart.getTime() + d*dayMs);
         hoverLabel.textContent = dt.toLocaleDateString('en-GB',{day:'2-digit', month:'short', year:'numeric'});
       }


### PR DESCRIPTION
## Summary
- ensure hover day changes only at gridline boundaries by using `Math.floor`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6097208b0832ead791b1ddc8a5ae6