### PR TITLE
Render daily labels without labelEvery

### DIFF
--- a/Project_Planner_App.html
+++ b/Project_Planner_App.html
@@ -30,7 +30,9 @@
     .tick{position:absolute; bottom:0; width:1px; height:12px; background:rgba(127,127,127,.35)}
     .tick.major{height:24px; background:rgba(127,127,127,.6)}
     .tick.week{height:18px; background:rgba(127,127,127,.5)}
-    .label{position:absolute; bottom:24px; transform:translateX(-50%); font-size:.75rem; color:var(--bs-secondary-color)}
+    .label{position:absolute; bottom:24px; transform:translateX(-50%); font-size:.75rem; color:var(--bs-secondary-color); white-space:nowrap}
+    .ruler.dense .label{transform:translateX(-50%) rotate(-90deg); transform-origin:bottom left}
+    .ruler.hide-labels .label{display:none}
     .week-label{position:absolute; bottom:34px; transform:translateX(-50%); font-size:.7rem; color:var(--bs-secondary-color)}
     .month{position:absolute; bottom:44px; transform:translateX(-50%); font-weight:600; color:var(--bs-body-color); font-size:.8rem}
     .grid{position:absolute; left:0; right:0; top:60px; bottom:0; pointer-events:none}
@@ -809,13 +811,6 @@
       byId('btn-export-plan-pdf').onclick = ()=> exportPlanPDF(p.id);
       byId('btn-export-plan-xlsx-basic').onclick = ()=> exportPlanExcel(p.id);
     }
-    function dayTicks(pxPerDay){
-      if(pxPerDay >= 36) return { labelEvery:1 };
-      if(pxPerDay >= 28) return { labelEvery:2 };
-      if(pxPerDay >= 20) return { labelEvery:3 };
-      if(pxPerDay >= 14) return { labelEvery:7 };
-      return { labelEvery:14 };
-    }
     function drawGantt(p, sched){
       const container = byId('ganttContent');
       const scroll = byId('ganttScroll');
@@ -858,17 +853,17 @@
     function drawRulerAndGrid(scroll, chartStart, totalDays, pxPerDay, contentHeight, phaseWindows){
       scroll.querySelectorAll('.ruler,.grid,.phase-tag,.sprint-line,.sprint-label,.hover-line,.hover-label').forEach(n=> n.remove());
       const labelPad = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--label-pad'));
-      const ruler = document.createElement('div'); ruler.className='ruler'; ruler.style.width = (totalDays*pxPerDay + labelPad) + 'px'; scroll.appendChild(ruler);
+      const ruler = document.createElement('div'); ruler.className='ruler'; ruler.style.width = (totalDays*pxPerDay + labelPad) + 'px';
+      if(pxPerDay < 14) ruler.classList.add('dense');
+      if(pxPerDay < 8) ruler.classList.add('hide-labels');
+      scroll.appendChild(ruler);
       const chartEndDate = new Date(chartStart.getTime()+totalDays*dayMs);
-      const {labelEvery} = dayTicks(pxPerDay);
       for(let d=0; d<=totalDays; d++){
         const x = labelPad + d*pxPerDay;
         const tick = document.createElement('div'); tick.className='tick'; tick.style.left = x+'px'; ruler.appendChild(tick);
-        if(d % labelEvery === 0){
-          const label = document.createElement('div'); label.className='label'; label.style.left = x+'px';
-          const dt = new Date(chartStart.getTime() + d*dayMs); label.textContent = dt.toLocaleDateString('en-GB',{day:'2-digit', month:'short'});
-          ruler.appendChild(label);
-        }
+        const label = document.createElement('div'); label.className='label'; label.style.left = x+'px';
+        const dt = new Date(chartStart.getTime() + d*dayMs); label.textContent = dt.getDate();
+        ruler.appendChild(label);
       }
       const firstMonth = new Date(chartStart); firstMonth.setDate(1);
       let m = new Date(firstMonth); if(m < chartStart) m.setMonth(m.getMonth()+1);


### PR DESCRIPTION
## Summary
- Display a label for every day on the Gantt chart and mark dense/hidden labels based on zoom
- Remove labelEvery/`dayTicks` logic
- Rotate or hide labels via CSS when days are densely packed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60babafc8832eaf2c89c6714b418d