### PR TITLE
Add release management and Gantt lane

### DIFF
--- a/Project_Planner_App.html
+++ b/Project_Planner_App.html
@@ -42,6 +42,7 @@
     .lane{position:relative; height:64px; border-bottom:1px dashed var(--bs-border-color); display:flex; align-items:center}
     .lane-label{position:absolute; left:12px; top:18px; width:160px; font-weight:600}
     .bar{position:absolute; top:16px; height:32px; border-radius:.5rem; display:flex; align-items:center; padding:0 .6rem; color:#000; font-weight:700; border:1px solid rgba(0,0,0,.18); user-select:none}
+    .release-bar{background:#6f42c1;color:#fff}
     .phase-tag{position:absolute; top:66px; height:20px; padding:0 .5rem; border:1px dashed var(--bs-border-color); border-radius:.5rem; font-size:.75rem; display:flex; align-items:center; color:var(--bs-secondary-color)}
     .phase-badge{background:var(--bs-secondary);color:#fff}
     .badge-lane{display:inline-flex;align-items:center;gap:.3rem}
@@ -232,6 +233,9 @@
     <button class="nav-link" id="tab-sprints" data-bs-toggle="tab" data-bs-target="#pane-sprints" type="button" role="tab">Sprints</button>
   </li>
   <li class="nav-item" role="presentation">
+    <button class="nav-link" id="tab-releases" data-bs-toggle="tab" data-bs-target="#pane-releases" type="button" role="tab">Releases</button>
+  </li>
+  <li class="nav-item" role="presentation">
     <button class="nav-link" id="tab-tasks" data-bs-toggle="tab" data-bs-target="#pane-tasks" type="button" role="tab">Tasks</button>
   </li>
   <li class="nav-item" role="presentation">
@@ -326,6 +330,22 @@
               <div class="table-responsive">
                 <table class="table table-hover align-middle" id="tbl-sprints">
                   <thead><tr><th style="width:25%">Name</th><th style="width:20%">Start</th><th style="width:20%">End</th><th style="width:15%">ID</th><th style="width:160px">Actions</th></tr></thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </div>
+
+            <div class="tab-pane fade" id="pane-releases" role="tabpanel">
+              <div class="d-flex justify-content-between align-items-center mb-2">
+                <div class="input-group" style="max-width:360px">
+                  <span class="input-group-text"><i class="bi bi-search"></i></span>
+                  <input id="search-releases" class="form-control" placeholder="Search releases">
+                </div>
+                <button class="btn btn-primary" id="btn-add-release"><i class="bi bi-plus-lg"></i> Add Release</button>
+              </div>
+              <div class="table-responsive">
+                <table class="table table-hover align-middle" id="tbl-releases">
+                  <thead><tr><th style="width:25%">Version</th><th style="width:20%">Code Freeze</th><th style="width:20%">Release</th><th style="width:15%">ID</th><th style="width:160px">Actions</th></tr></thead>
                   <tbody></tbody>
                 </table>
               </div>
@@ -788,7 +808,8 @@
         tbTeam.appendChild(tr);
       });
       const lf = byId('lane-filters');
-      lf.innerHTML = (p.lanes||[]).map(l=>
+      lf.innerHTML = `<div class="form-check form-check-inline"><input class="form-check-input" type="checkbox" id="chkReleases"><label class="form-check-label" for="chkReleases"><span class="badge-lane"><span class="dot" style="background:#6f42c1"></span>Releases</span></label></div>`+
+        (p.lanes||[]).map(l=>
         `<div class="form-check form-check-inline"><input class="form-check-input lane-filter" type="checkbox" value="${l.key}" id="chk${l.key}"><label class="form-check-label" for="chk${l.key}"><span class="badge-lane"><span class="dot" style="background:${l.color||effortTypeColor(l.key)}"></span>${l.name||effortTypeTitle(l.key)}</span></label></div>`
       ).join('');
       document.querySelectorAll('.lane-filter').forEach(chk=>{
@@ -800,6 +821,13 @@
           drawGantt(p, computeSchedule(p, aggregate(p, state.tasks, getTeam), state.meta.efficiency, getPhase, state.meta.startDate));
         };
       });
+      const chkRel = byId('chkReleases');
+      chkRel.checked = state.meta.showReleaseLane !== false;
+      chkRel.onchange = ()=>{
+        state.meta.showReleaseLane = chkRel.checked;
+        save();
+        drawGantt(p, computeSchedule(p, aggregate(p, state.tasks, getTeam), state.meta.efficiency, getPhase, state.meta.startDate));
+      };
       drawGantt(p, sched);
       renderPhaseBreakdownTables(p);
       byId('zoomRange').value = p.pxPerDay || state.meta.defaultPxPerDay || 18;
@@ -816,6 +844,21 @@
       const labelPad = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--label-pad'));
       const width = totalDays * pxPerDay + labelPad;
       const lanesOn = Array.from(document.querySelectorAll('.lane-filter')).filter(x=>x.checked).map(x=>x.value);
+      if(state.meta.showReleaseLane !== false && (state.releases||[]).length){
+        const lane = document.createElement('div'); lane.className='lane'; lane.style.width = width+'px'; lane.dataset.lane='releases';
+        const label = document.createElement('div'); label.className='lane-label'; label.textContent='Releases'; lane.appendChild(label);
+        (state.releases||[]).forEach(r=>{
+          const start = new Date(r.codeFreeze); const end = new Date(r.releaseDate);
+          if(end < sched.chartStart || start > sched.chartEnd) return;
+          const d0 = Math.max(0, Math.floor((start - sched.chartStart)/dayMs));
+          const d1 = Math.floor((end - sched.chartStart)/dayMs);
+          const bar = document.createElement('div'); bar.className='bar release-bar'; bar.textContent = r.version || '';
+          bar.style.left = (labelPad + d0*pxPerDay) + 'px';
+          bar.style.width = (Math.max(1, d1 - d0 + 1)*pxPerDay) + 'px';
+          lane.appendChild(bar);
+        });
+        container.appendChild(lane);
+      }
       sched.lanes.filter(l=> lanesOn.includes(l.key)).forEach(l=>{
         const lane = document.createElement('div'); lane.className='lane'; lane.style.width = width+'px'; lane.dataset.lane=l.key;
         const label = document.createElement('div'); label.className='lane-label'; label.textContent = l.name; lane.appendChild(label);
@@ -1524,6 +1567,16 @@
         tr.querySelector('.btn-outline-danger').onclick = ()=>{ if(confirm('Delete sprint?')){ state.sprints = state.sprints.filter(x=>x.id!==s.id); save(); refreshManage(); } };
         tbSp.appendChild(tr);
       });
+      const filterRl = (byId('search-releases').value||'').toLowerCase();
+      const tbRl = byId('tbl-releases').querySelector('tbody'); tbRl.innerHTML='';
+      (state.releases||[]).filter(r=> (r.version+' '+r.id).toLowerCase().includes(filterRl)).forEach(r=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${escapeHtml(r.version)}</td><td>${r.codeFreeze||''}</td><td>${r.releaseDate||''}</td><td><code>${r.id}</code></td>`+
+          `<td class="text-end"><button class=\"btn btn-sm btn-outline-primary\">Edit</button><button class=\"btn btn-sm btn-outline-danger ms-1\">Delete</button></td>`;
+        tr.querySelector('.btn-outline-primary').onclick = ()=> openEditor('release', r.id);
+        tr.querySelector('.btn-outline-danger').onclick = ()=>{ if(confirm('Delete release?')){ state.releases = state.releases.filter(x=>x.id!==r.id); save(); refreshManage(); } };
+        tbRl.appendChild(tr);
+      });
       const filterTk = (byId('search-tasks').value||'').toLowerCase();
       const tbTk = byId('tbl-tasks').querySelector('tbody'); tbTk.innerHTML='';
       state.tasks.filter(t=> (t.title+' '+t.id).toLowerCase().includes(filterTk)).forEach(t=>{
@@ -1566,6 +1619,7 @@
         }
       };
       byId('btn-add-sprint').onclick = ()=> openEditor('sprint', null);
+      byId('btn-add-release').onclick = ()=> openEditor('release', null);
       byId('btn-add-task').onclick = ()=> openEditor('task', null);
       byId('btn-add-effort-type').onclick = ()=> openEditor('effortType', null);
       byId('search-projects').oninput = refreshManage;
@@ -1573,6 +1627,7 @@
       byId('search-phases').oninput = refreshManage;
       byId('search-teams').oninput = refreshManage;
       byId('search-sprints').oninput = refreshManage;
+      byId('search-releases').oninput = refreshManage;
       byId('search-tasks').oninput = refreshManage;
       byId('search-effort-types').oninput = refreshManage;
       // Phase Tasks tab wiring
@@ -2011,6 +2066,25 @@
           save(); refreshManage(); buildProjects(); bootstrap.Modal.getInstance(byId('editModal')).hide();
         };
         del.onclick = ()=>{ if(confirm('Delete sprint?')){ state.sprints = state.sprints.filter(x=>x.id!==id); save(); refreshManage(); buildProjects(); bootstrap.Modal.getInstance(byId('editModal')).hide(); } };
+      }
+
+      if(kind==='release'){
+        const isEdit = !!id;
+        const data = isEdit ? state.releases.find(x=>x.id===id) : { id:'REL'+Math.random().toString(36).slice(2,6), version:'', codeFreeze:'', releaseDate:'' };
+        title.textContent = isEdit ? 'Edit Release' : 'Add Release';
+        form.innerHTML = [
+          field('Version', `<input id="f-version" class="form-control" value="${escapeHtml(data.version||'')}">`),
+          field('Code Freeze', `<input id="f-freeze" type="date" class="form-control" value="${escapeHtml(data.codeFreeze||'')}">`),
+          field('Release', `<input id="f-release" type="date" class="form-control" value="${escapeHtml(data.releaseDate||'')}">`),
+          field('ID', idInputHtml(data.id, isEdit)),
+        ].join('');
+        byId('editSave').onclick = ()=>{
+          const newId = val('f-id'); if(!isEdit && !ensureUniqueId(state.releases, newId)) return alert('ID already exists.');
+          const obj = { id: isEdit? data.id : newId, version: val('f-version'), codeFreeze: val('f-freeze'), releaseDate: val('f-release') };
+          if(isEdit){ Object.assign(state.releases.find(x=>x.id===id), obj); } else { state.releases.push(obj); }
+          save(); refreshManage(); buildProjects(); bootstrap.Modal.getInstance(byId('editModal')).hide();
+        };
+        del.onclick = ()=>{ if(confirm('Delete release?')){ state.releases = state.releases.filter(x=>x.id!==id); save(); refreshManage(); buildProjects(); bootstrap.Modal.getInstance(byId('editModal')).hide(); } };
       }
 
       if(kind==='effortType'){

--- a/data.js
+++ b/data.js
@@ -14,10 +14,12 @@ export const state = {
   teams: [],
   phases: [],
   sprints: [],
+  releases: [],
   meta: {
     startDate: new Date().toISOString().slice(0,10),
     efficiency: 1,
-    effortTypes: DEFAULT_EFFORT_TYPES.map(e=> ({...e}))
+    effortTypes: DEFAULT_EFFORT_TYPES.map(e=> ({...e})),
+    showReleaseLane: true,
   }
 };
 
@@ -36,6 +38,8 @@ export function load(){
     const raw = localStorage.getItem(STORAGE_KEY);
     if(raw) Object.assign(state, JSON.parse(raw));
     if(!Array.isArray(state.sprints)) state.sprints = [];
+    if(!Array.isArray(state.releases)) state.releases = [];
+    if(typeof state.meta?.showReleaseLane !== 'boolean') state.meta.showReleaseLane = true;
     if(Array.isArray(state.meta?.effortTypes)){
       if(typeof state.meta.effortTypes[0] === 'string'){
         const oldList = state.meta.effortTypes;
@@ -68,6 +72,8 @@ export function replaceState(newState){
   Object.keys(state).forEach(k => delete state[k]);
   Object.assign(state, newState);
   if(!Array.isArray(state.sprints)) state.sprints = [];
+  if(!Array.isArray(state.releases)) state.releases = [];
+  if(typeof state.meta?.showReleaseLane !== 'boolean') state.meta.showReleaseLane = true;
   ensurePlanLanes();
 }
 
@@ -78,6 +84,7 @@ export function mergeState(newData){
   if(Array.isArray(newData.teams)) newData.teams.forEach(t=> state.teams.push(t));
   if(Array.isArray(newData.phases)) newData.phases.forEach(ph=> state.phases.push(ph));
   if(Array.isArray(newData.sprints)) newData.sprints.forEach(s=> state.sprints.push(s));
+  if(Array.isArray(newData.releases)) newData.releases.forEach(r=> state.releases.push(r));
   if(newData.meta) Object.assign(state.meta, newData.meta);
   ensurePlanLanes();
 }
@@ -112,6 +119,24 @@ export function removeEffortType(key){
   state.proposals.forEach(p=>{
     if(p.overrides) Object.values(p.overrides).forEach(o=>{ delete o[key]; });
   });
+}
+
+export function addRelease(rel){
+  if(!Array.isArray(state.releases)) state.releases = [];
+  if(state.releases.some(r=>r.id===rel.id)) return;
+  state.releases.push({ id: rel.id, version: rel.version, codeFreeze: rel.codeFreeze, releaseDate: rel.releaseDate });
+}
+
+export function updateRelease(id, data){
+  const r = state.releases.find(x=>x.id===id);
+  if(!r) return;
+  if(data.version !== undefined) r.version = data.version;
+  if(data.codeFreeze !== undefined) r.codeFreeze = data.codeFreeze;
+  if(data.releaseDate !== undefined) r.releaseDate = data.releaseDate;
+}
+
+export function removeRelease(id){
+  state.releases = state.releases.filter(r=>r.id!==id);
 }
 
 const iso = d => d.toISOString().slice(0,10);

--- a/tests/data.test.js
+++ b/tests/data.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { state, replaceState, assignTaskToPhase, removeTaskFromPhase, getTasksByPhase, getTasksByProject, mergeState, ensureSprints } from '../data.js';
+import { state, replaceState, assignTaskToPhase, removeTaskFromPhase, getTasksByPhase, getTasksByProject, mergeState, ensureSprints, addRelease, updateRelease, removeRelease } from '../data.js';
 
 globalThis.localStorage = {
   getItem(){ return null; },
@@ -163,4 +163,14 @@ test('ensureSprints accepts custom start date', () => {
   assert.equal(state.sprints[0].start, '2024-03-04');
   const lastYear = new Date(state.sprints[state.sprints.length - 1].start).getUTCFullYear();
   assert.equal(lastYear, 2026);
+});
+
+test('release CRUD functions manage state.releases', () => {
+  replaceState({ projects:[], proposals:[], tasks:[], teams:[], phases:[], sprints:[], releases:[], meta:{} });
+  addRelease({id:'rel1', version:'1.0', codeFreeze:'2024-01-01', releaseDate:'2024-01-15'});
+  assert.equal(state.releases.length, 1);
+  updateRelease('rel1', {version:'1.1'});
+  assert.equal(state.releases[0].version, '1.1');
+  removeRelease('rel1');
+  assert.equal(state.releases.length, 0);
 });

--- a/ui/gantt.js
+++ b/ui/gantt.js
@@ -9,6 +9,29 @@ export function renderGantt(plan, aggr, eff, getPhase, startDate, options={}){
   const dayMs = 86400000;
   const totalDays = Math.max(1, Math.ceil((sched.chartEnd - sched.chartStart) / dayMs));
 
+  if(options.showReleases !== false && Array.isArray(options.releases) && options.releases.length){
+    const laneDiv = document.createElement('div');
+    laneDiv.className = 'gantt-lane releases';
+    const label = document.createElement('span');
+    label.className = 'gantt-label';
+    label.textContent = 'Releases';
+    laneDiv.appendChild(label);
+    options.releases.forEach(r => {
+      const start = new Date(r.codeFreeze);
+      const end = new Date(r.releaseDate);
+      const sOff = Math.max(0, Math.floor((start - sched.chartStart) / dayMs));
+      const eOff = Math.floor((end - sched.chartStart) / dayMs);
+      const bar = document.createElement('div');
+      bar.className = 'gantt-bar';
+      bar.style.left = `${(sOff / totalDays) * 100}%`;
+      bar.style.width = `${((eOff - sOff + 1) / totalDays) * 100}%`;
+      bar.style.background = r.color || '#6f42c1';
+      bar.textContent = r.version || '';
+      laneDiv.appendChild(bar);
+    });
+    root.appendChild(laneDiv);
+  }
+
   sched.lanes.forEach(lane => {
     const laneDiv = document.createElement('div');
     laneDiv.className = `gantt-lane ${lane.cls || ''}`;


### PR DESCRIPTION
## Summary
- Support tracking releases with version, code freeze, and release dates
- Display an optional Releases lane atop the Gantt chart
- Add CRUD UI and persistence for releases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a704b59ff8832e9ccb0b95e1921249